### PR TITLE
Don't prepend a length to PUBLISH payloads

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -449,7 +449,10 @@ class Client {
 		}
 
 		// Add Message to package and create header
-		$payload .= $this->convertString($message, $bytes);
+		$payload .= $message;
+
+		$bytes += strlen($message);
+
 		$header = $this->createHeader( 0x30 + ($qos<<1) , $bytes );
 
 		//


### PR DESCRIPTION
The MQTT specification states that there is no length prepended to the payload when publishing.

I've consequently removed the invocation of convertString() and just appended the message and added it's length directly.

[PUBLISH payload spec](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/errata01/os/mqtt-v3.1.1-errata01-os-complete.html#_Toc442180853) - note that the length of the payload is calculated by subtracting the variable header's length from the packet length.

I must note that the packet handling for the subscribe code decodes packets correctly.
