### PR TITLE
Hotfix php 5.3 compatibility and faulty member declaration

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -2,7 +2,7 @@
 /**
  * MQTT 3.1.1 library for PHP with TLS support
  *
- * @author Pekka Harjam‰ki <mcfizh@gmail.com>
+ * @author Pekka Harjam√§ki <mcfizh@gmail.com>
  * @license MIT
  * @version 0.3.0
  */
@@ -82,8 +82,8 @@ class Client {
 		$this->authPass = null;
 		$this->keepAlive = 15;
 		$this->packet = 1;
-		$this->topics = [];
-		$this->msgQueue = [];
+		$this->topics = array();
+		$this->msgQueue = array();
 
 		// Basic validation of clientid
 		if( preg_match("/[^0-9a-zA-Z]/",$clientID) )
@@ -128,7 +128,7 @@ class Client {
 		// Is encryption enabled?
 		if($this->connMethod!="tcp")
 		{
-			$socketContextOptions = [ "ssl" => [] ];
+			$socketContextOptions = array( "ssl" => array() );
 			$socketContextOptions["ssl"]["verify_peer_name"]=true;
 
 			if($this->caFile)
@@ -301,7 +301,7 @@ class Client {
 	 */
 	function setCryptoProtocol($protocol)
 	{
-		if(!in_array($protocol, ["ssl","tls","tlsv1.0","tlsv1.1","tlsv1.2","sslv3"]))
+		if(!in_array($protocol, array("ssl","tls","tlsv1.0","tlsv1.1","tlsv1.2","sslv3")))
 			return;
 		$this->connMethod = $protocol;
 	}
@@ -385,7 +385,7 @@ class Client {
 		// If for some reason topic is provided as string, convert it to array
 		// If $topics is neither array nor string, refuse to continue
 		if( !is_array($topics) && is_string($topics) )
-			$topics = [ $topics => [ 'qos' => 1 ] ];
+			$topics = array( $topics => array( 'qos' => 1 ) );
 		else if( !is_array($topics) )
 			return false;
 
@@ -514,14 +514,14 @@ class Client {
 		
 		// If message QoS = 1 , add message to queue
 		if($qos==1) {
-			$this->messageQueue[ $this->packet ] = [
+			$this->messageQueue[ $this->packet ] = array(
 				"topic" => $topic,
 				"message" => $message,
 				"qos" => $qos,
 				"retain" => $retain,
 				"time" => time(),
 				"attempt" => 1
-			];
+            );
 		}
 
 		//

--- a/src/Client.php
+++ b/src/Client.php
@@ -62,8 +62,8 @@ class Client {
 	/** @var int $keepAlive			Link keepalive time */
 	private $keepAlive;
 
-	/** @var array $msgQueue		Messages published with QoS 1 are placed here, until they are confirmed */
-	private $msgQueue;
+	/** @var array $messageQueue		Messages published with QoS 1 are placed here, until they are confirmed */
+	private $messageQueue;
 
 	/**
 	 * Class constructor
@@ -83,7 +83,7 @@ class Client {
 		$this->keepAlive = 15;
 		$this->packet = 1;
 		$this->topics = array();
-		$this->msgQueue = array();
+		$this->messageQueue = array();
 
 		// Basic validation of clientid
 		if( preg_match("/[^0-9a-zA-Z]/",$clientID) )
@@ -521,7 +521,7 @@ class Client {
 				"retain" => $retain,
 				"time" => time(),
 				"attempt" => 1
-            );
+			);
 		}
 
 		//


### PR DESCRIPTION
- Client wasn't PHP 5.3 compatible due to short array syntax usage
- Member variable was declared and initialized in constructor, but different variable used throughout the code