### PR TITLE
Prevent double escaping forward slash

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -2,7 +2,7 @@
 /**
  * MQTT 3.1.1 library for PHP with TLS support
  *
- * @author Pekka Harjam‰ki <mcfizh@gmail.com>
+ * @author Pekka Harjam√§ki <mcfizh@gmail.com>
  * @license MIT
  * @version 0.3.0
  */
@@ -577,7 +577,7 @@ class Client {
 		$found = false;
 		foreach($this->topics as $topic=>$data) {
 
-			$t_topic = str_replace("+","[^\/]*", $topic);
+			$t_topic = str_replace("+","[^/]*", $topic);
 			$t_topic = str_replace("/","\/",$t_topic);
 			$t_topic = str_replace("$","\$",$t_topic);
 			$t_topic = str_replace("#",".*",$t_topic);


### PR DESCRIPTION
When subscribing to a topic with a plus in it's topic, it passes through a regex. This regex will replace any occurrences of the `+` sign to `[^\/]*`. 

However, the next rule will escape the forward slash, which was already escaped by the previous `str_replace`, which will produce a warning and on top of that, the topic won't match:

```
PHP Warning:  preg_match(): Unknown modifier ']' in /var/www/vendor/mcfish/libmqtt/src/Client.php on line 586
```

This commit fixes it by providing an unescaped forward slash in the first str_replace, and then allowing the second str_replace to escape the first one.